### PR TITLE
Fix certification URL

### DIFF
--- a/server/views/certificate/full-stack.jade
+++ b/server/views/certificate/full-stack.jade
@@ -29,4 +29,4 @@ include styles
 					strong Quincy Larson
 				p Executive Director, freeCodeCamp.org
 			.row
-				p.verify Verify this certification at: https://www.freecodecamp.org/certification/#{username}/responsive-web-design
+				p.verify Verify this certification at: https://www.freecodecamp.org/certification/#{username}/full-stack


### PR DESCRIPTION
<!-- freeCodeCamp Pull Request Template -->

<!-- IMPORTANT Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `staging` branch of freeCodeCamp.
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.org/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] All new and existing tests pass the command `npm test`. Use `git commit --amend` to amend any fixes.

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [ ] Addressed currently open issue (replace XXXXX with an issue no in next line)

Closes #XXXXX

#### Description
<!-- Describe your changes in detail -->
The URL displayed on the certificate pointed to the responsive web design certificate, rather than the full stack certificate it should point to. I've changed it to point to the right page. 